### PR TITLE
apply hierarchical ontology interface to keyword filter

### DIFF
--- a/src/controllers/OntologyController.ts
+++ b/src/controllers/OntologyController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { AppDataSource } from '../db/data-source.js';
 import { OntologyClasses } from '../db/entities/OntologyClass.js';
+import { OntologyRelations } from '../db/entities/OntologyRelation.js';
 
 export class OntologyController {
   // Fetch ontology tiles data for parents
@@ -137,18 +138,59 @@ export class OntologyController {
   async getOntologyTree(req: Request, res: Response) {
     try {
       const ontologyRepository = AppDataSource.getRepository(OntologyClasses);
-      const ontologyTree = await ontologyRepository.find({
-        relations: ['childRelations', 'childRelations.child_class'],
+      const relationRepository = AppDataSource.getRepository(OntologyRelations);
+      const excludedLabels = this.excludedLabels().map((label) => label.toLowerCase());
+
+      const classes = await ontologyRepository.find({
+        where: { is_active: true },
+      });
+      const relations = await relationRepository.find({
+        relations: ['parent_class', 'child_class'],
       });
 
-      const treeData = ontologyTree.map((classItem) => ({
-        id: classItem.id,
-        label: classItem.label.replace(/_/g, ' '),
-        children: classItem.childRelations.map((relation) => ({
-          id: relation.child_class.id,
-          label: relation.child_class.label.replace(/_/g, ' '),
-        })),
-      }));
+      const classById = new Map<number, OntologyClasses>();
+      const childIds = new Set<number>();
+      const childrenByParentId = new Map<number, OntologyClasses[]>();
+
+      classes.forEach((classItem) => {
+        if (!excludedLabels.includes(classItem.label.toLowerCase())) {
+          classById.set(classItem.id, classItem);
+        }
+      });
+
+      relations.forEach((relation) => {
+        const parent = relation.parent_class as OntologyClasses | undefined;
+        const child = relation.child_class as OntologyClasses | undefined;
+        if (!parent || !child || !classById.has(parent.id) || !classById.has(child.id)) return;
+
+        childIds.add(child.id);
+        const siblings = childrenByParentId.get(parent.id) || [];
+        if (!siblings.some((sibling) => sibling.id === child.id)) {
+          siblings.push(child);
+        }
+        childrenByParentId.set(parent.id, siblings);
+      });
+
+      const buildNode = (classItem: OntologyClasses, visited = new Set<number>()): any => {
+        const nextVisited = new Set(visited);
+        nextVisited.add(classItem.id);
+
+        const children = (childrenByParentId.get(classItem.id) || [])
+          .filter((child) => !nextVisited.has(child.id))
+          .sort((left, right) => left.label.localeCompare(right.label))
+          .map((child) => buildNode(child, nextVisited));
+
+        return {
+          id: classItem.id,
+          label: classItem.label.replace(/_/g, ' '),
+          children,
+        };
+      };
+
+      const treeData = Array.from(classById.values())
+        .filter((classItem) => !childIds.has(classItem.id))
+        .sort((left, right) => left.label.localeCompare(right.label))
+        .map((classItem) => buildNode(classItem));
 
       res.json({ tree: treeData });
     } catch (error) {

--- a/src/controllers/ReviewController.ts
+++ b/src/controllers/ReviewController.ts
@@ -16,7 +16,9 @@ export class ReviewController {
       logger.info('Starting metadata validation');
 
       // Separate the items by catalog type
-      const slcItemCatalogs = jsonArray.filter((item) => item.catalog_type === 'SLCItem');
+      const slcItemCatalogs = jsonArray.filter(
+        (item) => item.catalog_type === 'SLCItem' || item.catalog_type === 'SLCItemCatalog',
+      );
       const slcToolsCatalogs = jsonArray.filter((item) => item.catalog_type === 'SLCToolsCatalog');
       const datasetCatalogs = jsonArray.filter((item) => item.catalog_type === 'DatasetCatalog');
 

--- a/src/controllers/SearchController.ts
+++ b/src/controllers/SearchController.ts
@@ -12,6 +12,7 @@ const catalogMap: { [key: string]: typeof slc_item_catalog | typeof slc_tools_ca
 };
 
 const FILTER_FIELDS = [
+  { key: 'keywords', label: 'Keywords', itemField: 'keywords', legacyQueryKeys: [], type: 'ontology' },
   { key: 'features', label: 'Features', itemField: 'features', legacyQueryKeys: [] },
   { key: 'tools', label: 'Tools', itemField: 'platform_name', legacyQueryKeys: ['tool'] },
   { key: 'natural_language', label: 'Natural Language', itemField: 'natural_language', legacyQueryKeys: [] },
@@ -116,8 +117,8 @@ export class SearchController {
       return {
         key: field.key,
         label: field.label,
-        type: 'flat',
-        choices,
+        type: 'type' in field ? field.type : 'flat',
+        choices: 'type' in field && field.type === 'ontology' ? [] : choices,
       };
     });
 

--- a/src/db/entities/DatasetCatalog.ts
+++ b/src/db/entities/DatasetCatalog.ts
@@ -5,13 +5,13 @@ export class dataset_catalog extends BaseEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   title?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   platform?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   dataset_name?: string;
 
   @Column('text', { nullable: true })
@@ -29,37 +29,37 @@ export class dataset_catalog extends BaseEntity {
   @Column('text', { nullable: true })
   contributors!: Contributor[];
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   publisher?: string;
 
-  @Column({ length: 1024, nullable: true })
+  @Column({ type: 'varchar', length: 1024, nullable: true })
   resource_url?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   resource_url_type?: string;
 
   @Column('text', { nullable: true })
   bibtex_source?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   creator?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   given_name?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   family_name?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   name_identifier?: string;
 
   @Column('text', { nullable: true })
   affiliation?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   availability?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   rights?: string;
 
   @Column('text', { nullable: true })
@@ -77,25 +77,25 @@ export class dataset_catalog extends BaseEntity {
   @Column({ type: 'int', nullable: true })
   number_of_semesters?: number;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   data_protection?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   measurement_type?: string;
 
   @Column('text', { nullable: true })
   data_processing?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   population?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   units_number?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   task_number?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   sample_size?: string;
 
   @Column('text', { nullable: true })
@@ -104,22 +104,22 @@ export class dataset_catalog extends BaseEntity {
   @Column('text', { nullable: true })
   country?: string[];
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   educational_institution?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   data_standard?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   learning_environment?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   aggregation?: string;
 
-  @Column({ length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   aggregation_level?: string;
 
-  @Column({ length: 1024, nullable: true })
+  @Column({ type: 'varchar', length: 1024, nullable: true })
   related_publication_url?: string;
 
   @Column('text', { nullable: true })

--- a/src/db/entities/SLCToolsCatalog.ts
+++ b/src/db/entities/SLCToolsCatalog.ts
@@ -7,42 +7,42 @@ export class slc_tools_catalog extends BaseEntity implements CatalogInterface {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column()
+  @Column({ type: 'varchar' })
   @IsNotEmpty()
   @IsString()
   catalog_type!: string;
 
-  @Column()
+  @Column({ type: 'varchar' })
   @IsNotEmpty()
   @IsString()
   platform_name!: string;
 
-  @Column()
+  @Column({ type: 'varchar' })
   @IsNotEmpty()
   @IsUrl()
   url!: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   @IsNotEmpty()
   @IsString()
   description!: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   @IsOptional()
   @IsString()
   license?: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   @IsOptional()
   @IsString()
   interface?: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   @IsOptional()
   @IsString()
   contact_email!: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   @IsOptional()
   @IsString()
   lti_credentials?: string;

--- a/src/db/entities/ValidationResults.ts
+++ b/src/db/entities/ValidationResults.ts
@@ -5,7 +5,7 @@ export class ValidationResults extends BaseEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column()
+  @Column({ type: 'varchar' })
   user!: string;
 
   @CreateDateColumn()

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -203,7 +203,7 @@
 }
 
 .search-sidebar {
-  width: 250px;
+  width: 310px;
   padding: 1rem;
   background-color: #f1f1f1;
   border: 1px solid #ddd;
@@ -314,9 +314,9 @@
 }
 
 .search-sidebar .ontology-filter-expand {
-  flex: 0 0 1.15rem;
-  width: 1.15rem;
-  height: 1.35rem;
+  flex: 0 0 1.5rem;
+  width: 1.5rem;
+  height: 1.5rem;
   margin: 0.02rem 0 0;
   padding: 0;
   border: 1px solid transparent;
@@ -325,7 +325,7 @@
   color: #333;
   cursor: pointer;
   font-weight: 700;
-  font-size: 0.82rem;
+  font-size: 1.05rem;
   line-height: 1;
 }
 

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -216,13 +216,13 @@
   margin-bottom: 1rem;
 }
 
-.search-sidebar legend {
-  margin-bottom: 0.35rem;
-}
-
-.search-sidebar legend label {
-  font-size: 1rem;
-  font-weight: 600;
+.filter-section {
+  margin: 0 0 0.75rem;
+  padding: 0;
+  border: 1px solid #d6d9dd;
+  border-radius: 6px;
+  background-color: #fff;
+  overflow: hidden;
 }
 
 .search-sidebar label {
@@ -243,6 +243,125 @@
 
 .search-sidebar button:hover {
   background-color: #0056b3;
+}
+
+.search-sidebar .filter-section-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  width: 100%;
+  margin: 0;
+  min-height: 3rem;
+  padding: 0.6rem 0.85rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #222;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: left;
+}
+
+.search-sidebar .filter-section-toggle:hover {
+  background-color: #f6f7f8;
+  color: #111;
+}
+
+.filter-section-caret {
+  flex: 0 0 1rem;
+  order: 2;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+}
+
+.filter-section-options {
+  padding: 0.35rem 0.85rem 0.75rem;
+  border-top: 1px solid #eceff1;
+}
+
+.ontology-filter-tree {
+  max-height: 440px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.ontology-filter-list {
+  list-style: none;
+  margin: 0;
+  padding-left: 0.7rem;
+}
+
+.ontology-filter-tree > .ontology-filter-list {
+  padding-left: 0;
+}
+
+.ontology-filter-node {
+  margin: 0.1rem 0;
+}
+
+.ontology-filter-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.2rem;
+  min-height: 1.45rem;
+  width: 100%;
+}
+
+.search-sidebar .ontology-filter-expand {
+  flex: 0 0 1.15rem;
+  width: 1.15rem;
+  height: 1.35rem;
+  margin: 0.02rem 0 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: #333;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.82rem;
+  line-height: 1;
+}
+
+.search-sidebar .ontology-filter-expand:hover:not(:disabled) {
+  background-color: #e2e6ea;
+  color: #111;
+}
+
+.search-sidebar .ontology-filter-expand:disabled {
+  cursor: default;
+  visibility: hidden;
+}
+
+.ontology-filter-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 0;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.ontology-filter-checkbox {
+  flex: 0 0 auto;
+  margin-top: 0.05rem;
+}
+
+.ontology-filter-children {
+  margin-left: 1.05rem;
+}
+
+.ontology-filter-loading {
+  color: #6c757d;
+  font-size: 0.9rem;
 }
 
 .search-content {

--- a/src/public/js/searchparams.js
+++ b/src/public/js/searchparams.js
@@ -2,6 +2,7 @@ window.currentItems = [];
 
 document.addEventListener('DOMContentLoaded', function () {
   let activeKeyword = null;
+  const ontologyDescendantsByLabel = new Map();
 
   function parseKeywords(raw) {
     if (!raw) return [];
@@ -55,6 +56,142 @@ document.addEventListener('DOMContentLoaded', function () {
     }, {});
   }
 
+  function setFilterSectionExpanded(key, isExpanded) {
+    const toggle = document.querySelector(`[data-filter-toggle="${key}"]`);
+    const optionsContainer = document.querySelector(`[data-filter-options="${key}"]`);
+    const caret = toggle?.querySelector('.filter-section-caret');
+
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    }
+    if (caret) {
+      caret.textContent = isExpanded ? 'v' : '>';
+    }
+    if (optionsContainer) {
+      optionsContainer.style.display = isExpanded ? '' : 'none';
+    }
+  }
+
+  function collectOntologyLabels(node) {
+    const labels = [node.label];
+    (node.children || []).forEach((child) => {
+      labels.push(...collectOntologyLabels(child));
+    });
+    return labels;
+  }
+
+  function indexOntologyNode(node) {
+    ontologyDescendantsByLabel.set(node.label, collectOntologyLabels(node));
+    (node.children || []).forEach(indexOntologyNode);
+  }
+
+  function getFilterMatchValues(section, selectedValues) {
+    if (section.key !== 'keywords') return selectedValues;
+
+    return [
+      ...new Set(
+        selectedValues.flatMap((selectedValue) => ontologyDescendantsByLabel.get(selectedValue) || [selectedValue]),
+      ),
+    ];
+  }
+
+  function renderOntologyNodes(nodes, selectedValues) {
+    const list = document.createElement('ul');
+    list.className = 'ontology-filter-list';
+
+    nodes.forEach((node) => {
+      const item = document.createElement('li');
+      item.className = 'ontology-filter-node';
+
+      const row = document.createElement('div');
+      row.className = 'ontology-filter-row';
+
+      const children = node.children || [];
+      const expandButton = document.createElement('button');
+      expandButton.type = 'button';
+      expandButton.className = 'ontology-filter-expand';
+      expandButton.textContent = children.length > 0 ? '>' : '';
+      expandButton.setAttribute('aria-label', children.length > 0 ? `Expand ${node.label}` : '');
+      expandButton.disabled = children.length === 0;
+      if (children.length === 0) {
+        expandButton.setAttribute('aria-hidden', 'true');
+      }
+
+      const label = document.createElement('label');
+      label.className = 'ontology-filter-label';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'filter-option-input ontology-filter-checkbox';
+      checkbox.dataset.filterOption = 'keywords';
+      checkbox.name = 'keywords';
+      checkbox.value = node.label;
+      checkbox.checked = selectedValues.has(node.label);
+      checkbox.addEventListener('change', function () {
+        if (this.checked) setFilterSectionExpanded('keywords', true);
+        updateResults();
+      });
+
+      label.appendChild(checkbox);
+      label.appendChild(document.createTextNode(node.label));
+      row.appendChild(expandButton);
+      row.appendChild(label);
+      item.appendChild(row);
+
+      if (children.length > 0) {
+        const childWrapper = document.createElement('div');
+        childWrapper.className = 'ontology-filter-children';
+        childWrapper.hidden = true;
+        childWrapper.appendChild(renderOntologyNodes(children, selectedValues));
+        item.appendChild(childWrapper);
+
+        expandButton.addEventListener('click', function () {
+          const isExpanded = !childWrapper.hidden;
+          childWrapper.hidden = isExpanded;
+          expandButton.textContent = isExpanded ? '>' : 'v';
+          expandButton.setAttribute('aria-label', `${isExpanded ? 'Expand' : 'Collapse'} ${node.label}`);
+        });
+      }
+
+      list.appendChild(item);
+    });
+
+    return list;
+  }
+
+  async function initOntologyFilters() {
+    const treeContainers = Array.from(document.querySelectorAll('[data-ontology-tree="keywords"]'));
+    if (treeContainers.length === 0) return;
+
+    try {
+      const response = await fetch('/ontology/tree');
+      if (!response.ok) throw new Error('Unable to load ontology tree');
+
+      const data = await response.json();
+      const tree = data.tree || [];
+      tree.forEach(indexOntologyNode);
+
+      treeContainers.forEach((container) => {
+        const selectedValues = new Set(
+          (container.dataset.selectedValues || '')
+            .split('|')
+            .map((value) => value.trim())
+            .filter(Boolean),
+        );
+
+        container.innerHTML = '';
+        container.appendChild(renderOntologyNodes(tree, selectedValues));
+      });
+
+      updateResults();
+    } catch (error) {
+      console.error('Error loading ontology tree:', error);
+      treeContainers.forEach((container) => {
+        container.innerHTML = '<div class="ontology-filter-loading">Unable to load keywords.</div>';
+      });
+    }
+  }
+
   let currentItems = [...allItems];
   window.currentItems = [...currentItems];
   let searchResults = [...allItems];
@@ -72,12 +209,9 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       const feature = e.target.dataset.feature;
       const featureCheckbox = form.querySelector(`[data-filter-option="features"][value="${feature}"]`);
-      const featuresToggle = form.querySelector('[data-filter-toggle="features"]');
-      const featuresOptions = form.querySelector('[data-filter-options="features"]');
       if (featureCheckbox) {
         featureCheckbox.checked = true;
-        if (featuresToggle) featuresToggle.checked = true;
-        if (featuresOptions) featuresOptions.style.display = '';
+        setFilterSectionExpanded('features', true);
         updateResults();
       }
     }
@@ -104,7 +238,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let filteredItems = searchResults;
 
     (window.filterSections || []).forEach((section) => {
-      const selectedValues = selectedFilters[section.key] || [];
+      const selectedValues = getFilterMatchValues(section, selectedFilters[section.key] || []);
       if (selectedValues.length === 0) return;
 
       const itemField = section.key === 'tools' ? 'platform_name' : section.key;
@@ -283,21 +417,10 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   document.querySelectorAll('[data-filter-toggle]').forEach((toggle) => {
-    toggle.addEventListener('change', function () {
+    toggle.addEventListener('click', function () {
       const key = this.dataset.filterToggle;
-      const optionsContainer = document.querySelector(`[data-filter-options="${key}"]`);
-      const optionInputs = Array.from(document.querySelectorAll(`[data-filter-option="${key}"]`));
-
-      if (this.checked) {
-        if (optionsContainer) optionsContainer.style.display = '';
-        return;
-      }
-
-      if (optionsContainer) optionsContainer.style.display = 'none';
-      optionInputs.forEach((input) => {
-        input.checked = false;
-      });
-      updateResults();
+      const isExpanded = this.getAttribute('aria-expanded') === 'true';
+      setFilterSectionExpanded(key, !isExpanded);
     });
   });
 
@@ -305,10 +428,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (checkbox.dataset.filterOption) {
       checkbox.addEventListener('change', function () {
         const key = this.dataset.filterOption;
-        const toggle = document.querySelector(`[data-filter-toggle="${key}"]`);
         const selectedCount = document.querySelectorAll(`[data-filter-option="${key}"]:checked`).length;
-        if (toggle && selectedCount > 0) {
-          toggle.checked = true;
+        if (selectedCount > 0) {
+          setFilterSectionExpanded(key, true);
         }
         updateResults();
       });
@@ -377,24 +499,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
     (window.filterSections || []).forEach((section) => {
       const values = params.getAll(section.key);
-      const toggle = document.querySelector(`[data-filter-toggle="${section.key}"]`);
-      const optionsContainer = document.querySelector(`[data-filter-options="${section.key}"]`);
-
       document.querySelectorAll(`[data-filter-option="${section.key}"]`).forEach((cb) => {
         if (values.includes(cb.value)) cb.checked = true;
       });
 
-      if (toggle && values.length > 0) {
-        toggle.checked = true;
-      }
-
-      if (optionsContainer && values.length > 0) {
-        optionsContainer.style.display = '';
+      if (values.length > 0) {
+        setFilterSectionExpanded(section.key, true);
       }
     });
   }
 
   applyFiltersFromURL();
+  initOntologyFilters();
 
   const initialQuery = new URLSearchParams(window.location.search).get('query');
   if (initialQuery) {

--- a/src/views/partials/filter.ejs
+++ b/src/views/partials/filter.ejs
@@ -6,39 +6,51 @@
 
     <% sections.forEach(section => { %>
       <% const selectedValues = activeFilters[section.key] || []; %>
-      <fieldset class="filter-section" data-filter-section="<%= section.key %>">
-        <legend>
-          <label>
-            <input
-              type="checkbox"
-              class="filter-section-toggle"
-              data-filter-toggle="<%= section.key %>"
-              <%= selectedValues.length > 0 ? 'checked' : '' %>
-            />
-            <%= section.label %>
-          </label>
-        </legend>
+      <section class="filter-section" data-filter-section="<%= section.key %>">
+        <div class="filter-section-header">
+          <button
+            type="button"
+            class="filter-section-toggle"
+            data-filter-toggle="<%= section.key %>"
+            aria-expanded="<%= selectedValues.length > 0 ? 'true' : 'false' %>"
+            aria-controls="filter-options-<%= section.key %>"
+          >
+            <span class="filter-section-caret"><%= selectedValues.length > 0 ? 'v' : '>' %></span>
+            <span><%= section.label %></span>
+          </button>
+        </div>
 
         <div
+          id="filter-options-<%= section.key %>"
           class="filter-section-options"
           data-filter-options="<%= section.key %>"
           style="<%= selectedValues.length > 0 ? '' : 'display: none;' %>"
         >
-          <% section.choices.forEach(choice => { %>
-            <label>
-              <input
-                type="checkbox"
-                class="filter-option-input"
-                data-filter-option="<%= section.key %>"
-                name="<%= section.key %>"
-                value="<%= choice %>"
-                <%= selectedValues.includes(choice) ? 'checked' : '' %>
-              />
-              <%= choice %>
-            </label>
-          <% }) %>
+          <% if (section.type === 'ontology') { %>
+            <div
+              class="ontology-filter-tree"
+              data-ontology-tree="<%= section.key %>"
+              data-selected-values="<%= selectedValues.join('|') %>"
+            >
+              <div class="ontology-filter-loading">Loading...</div>
+            </div>
+          <% } else { %>
+            <% section.choices.forEach(choice => { %>
+              <label>
+                <input
+                  type="checkbox"
+                  class="filter-option-input"
+                  data-filter-option="<%= section.key %>"
+                  name="<%= section.key %>"
+                  value="<%= choice %>"
+                  <%= selectedValues.includes(choice) ? 'checked' : '' %>
+                />
+                <%= choice %>
+              </label>
+            <% }) %>
+          <% } %>
         </div>
-      </fieldset>
+      </section>
     <% }) %>
 
     <input type="hidden" name="query" value="<%= typeof query !== 'undefined' ? query : '' %>">


### PR DESCRIPTION
Working on the ontology-based keyword filter interface in the catalog search sidebar. The sidebar has been widened to make longer category names easier to read. The expand/collapse arrow for ontology parent nodes has also been enlarged, with a bigger click area, so users can more easily open and close ontology branches.